### PR TITLE
Fix cleanup workflow triggers and docs gitignore

### DIFF
--- a/.github/workflows/cleanup-commands.yml
+++ b/.github/workflows/cleanup-commands.yml
@@ -10,8 +10,6 @@ on:
       - main
     paths:
       - 'commands/**/*.md'
-      - 'scripts/clean_command_names.py'
-      - '.github/workflows/cleanup-commands.yml'
 
   pull_request:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ docs/.doctrees/
 config/
 
 # Ignore docs/ directory except specific sync tracking files
-docs/
+docs/*
 !docs/.framework-sync-commit
 !docs/SYNC_SYSTEM.md
 PR_DESCRIPTION.md


### PR DESCRIPTION
Updated `.github/workflows/cleanup-commands.yml` to remove `scripts/clean_command_names.py` and the workflow file itself from trigger paths, preventing redundant runs. Also modified `.gitignore` to use `docs/*` instead of `docs/`, allowing specific files inside `docs/` to be tracked via exceptions (e.g., `!docs/.framework-sync-commit`), which fixes the `git add` failure in the sync workflow.

---
*PR created automatically by Jules for task [5441708751245836363](https://jules.google.com/task/5441708751245836363) started by @Utakata*